### PR TITLE
chore(package.json): chai types no longer needed in rc4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,9 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "jquery": "^3.1.1",
-    "rxjs": "^5.0.0-rc.1"
+    "rxjs": "^5.0.0-rc.4"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.34",
     "@types/jquery": "^2.0.33",
     "@types/node": "^6.0.46",
     "css-loader": "^0.25.0",


### PR DESCRIPTION
https://github.com/ReactiveX/rxjs/issues/2112 was resolved in rc4, confirmed by several community members.